### PR TITLE
🔒 [security fix] require authentication for REQUEST_BINDER intent

### DIFF
--- a/manager/src/main/assets/rish
+++ b/manager/src/main/assets/rish
@@ -22,4 +22,8 @@ fi
 
 # Replace "PKG" with the application id of your terminal app
 [ -z "$RISH_APPLICATION_ID" ] && export RISH_APPLICATION_ID="PKG"
+
+# Set SHIZUKU_TOKEN if you have authentication enabled in Shizuku app
+# [ -z "$SHIZUKU_TOKEN" ] && export SHIZUKU_TOKEN="YOUR_TOKEN_HERE"
+
 /system/bin/app_process -Djava.class.path="$DEX" /system/bin --nice-name=rish rikka.shizuku.shell.ShizukuShellLoader "$@"

--- a/manager/src/main/java/af/shizuku/manager/legacy/ShellRequestHandlerActivity.kt
+++ b/manager/src/main/java/af/shizuku/manager/legacy/ShellRequestHandlerActivity.kt
@@ -5,12 +5,78 @@ import android.widget.Toast
 import af.shizuku.manager.app.AppActivity
 import af.shizuku.manager.shell.ShellBinderRequestHandler
 
+import af.shizuku.manager.ShizukuSettings
+import af.shizuku.manager.R
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import af.shizuku.manager.MainActivity
+
 class ShellRequestHandlerActivity : AppActivity() {
+
+    companion object {
+        private const val CHANNEL_ID = "auth_errors"
+        private const val CHANNEL_NAME = "Authentication Errors"
+        private const val NOTIFICATION_ID = 1450
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        ShellBinderRequestHandler.handleRequest(this, intent)
+        val authToken = intent.getStringExtra("auth")
+        val expectedToken = ShizukuSettings.getAuthToken()
+
+        if (authToken.isNullOrEmpty()) {
+            notify(
+                R.string.notification_auth_missing_title,
+                R.string.notification_auth_missing_message
+            )
+        } else if (authToken != expectedToken) {
+            notify(
+                R.string.notification_auth_invalid_title,
+                R.string.notification_auth_invalid_message
+            )
+        } else {
+            ShellBinderRequestHandler.handleRequest(this, intent, true)
+        }
         finish()
+    }
+
+    private fun notify(title: Int, message: Int) {
+        val titleStr = getString(title)
+        val messageStr = getString(message)
+
+        val nm = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_HIGH
+            )
+            nm.createNotificationChannel(channel)
+        }
+
+        val launchIntent = Intent(this, MainActivity::class.java).apply {
+            addFlags(
+                Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP
+            )
+        }
+        val launchPendingIntent = PendingIntent.getActivity(
+            this, 0, launchIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(titleStr)
+            .setContentText(messageStr)
+            .setContentIntent(launchPendingIntent)
+            .setAutoCancel(true)
+            .setSmallIcon(R.drawable.ic_system_icon)
+            .build()
+
+        nm.notify(NOTIFICATION_ID, notification)
     }
 }

--- a/manager/src/main/java/af/shizuku/manager/receiver/BinderRequestReceiver.kt
+++ b/manager/src/main/java/af/shizuku/manager/receiver/BinderRequestReceiver.kt
@@ -5,9 +5,17 @@ import android.content.Context
 import android.content.Intent
 import af.shizuku.manager.shell.ShellBinderRequestHandler
 
-class BinderRequestReceiver : BroadcastReceiver() {
+class BinderRequestReceiver : AuthenticatedReceiver() {
+
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action != "rikka.shizuku.intent.action.REQUEST_BINDER") return
-        ShellBinderRequestHandler.handleRequest(context, intent)
+        if (intent.action != "rikka.shizuku.intent.action.REQUEST_BINDER") {
+            return
+        }
+
+        super.onReceive(context, intent)
+    }
+
+    override fun onAuthenticated(context: Context, intent: Intent) {
+        ShellBinderRequestHandler.handleRequest(context, intent, true)
     }
 }

--- a/manager/src/main/java/af/shizuku/manager/shell/ShellBinderRequestHandler.kt
+++ b/manager/src/main/java/af/shizuku/manager/shell/ShellBinderRequestHandler.kt
@@ -8,11 +8,21 @@ import af.shizuku.manager.ktx.loge
 import af.shizuku.manager.utils.Logger.LOGGER
 import rikka.shizuku.Shizuku
 
+import af.shizuku.manager.ShizukuSettings
+
 object ShellBinderRequestHandler {
 
-    fun handleRequest(context: Context, intent: Intent): Boolean {
+    fun handleRequest(context: Context, intent: Intent, requireAuth: Boolean = false): Boolean {
         if (intent.action != "rikka.shizuku.intent.action.REQUEST_BINDER") {
             return false
+        }
+
+        if (requireAuth) {
+            val authToken = intent.getStringExtra("auth")
+            val expectedToken = ShizukuSettings.getAuthToken()
+            if (authToken != expectedToken) {
+                return false
+            }
         }
 
         val binder = intent.getBundleExtra("data")?.getBinder("binder") ?: return false

--- a/shell/src/main/java/rikka/shizuku/shell/ShizukuShellLoader.java
+++ b/shell/src/main/java/rikka/shizuku/shell/ShizukuShellLoader.java
@@ -53,10 +53,16 @@ public class ShizukuShellLoader {
         Bundle data = new Bundle();
         data.putBinder("binder", receiverBinder);
 
+        String authToken = System.getenv("SHIZUKU_TOKEN");
+
         Intent intent = new Intent("rikka.shizuku.intent.action.REQUEST_BINDER")
                 .setPackage("af.shizuku.plus.api")
                 .addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
                 .putExtra("data", data);
+
+        if (!TextUtils.isEmpty(authToken)) {
+            intent.putExtra("auth", authToken);
+        }
 
         IBinder amBinder = ServiceManager.getService("activity");
         IActivityManager am;
@@ -83,12 +89,18 @@ public class ShizukuShellLoader {
             System.err.println("broadcastIntent fails on Android 8.0 or 8.1, fallback to startActivity");
             System.err.flush();
 
+            Intent baseActivityIntent = new Intent("rikka.shizuku.intent.action.REQUEST_BINDER")
+                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT)
+                    .putExtra("data", data);
+
+            if (!TextUtils.isEmpty(authToken)) {
+                baseActivityIntent.putExtra("auth", authToken);
+            }
+
             Intent activityIntent = Intent.createChooser(
-                    new Intent("rikka.shizuku.intent.action.REQUEST_BINDER")
-                            .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                            .addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT)
-                            .putExtra("data", data),
+                    baseActivityIntent,
                     "Request binder from Shizuku"
             );
 


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
This PR fixes a security vulnerability where exported components in the Shizuku Manager app handled binder requests without any authentication. Specifically, `BinderRequestReceiver` and `ShellRequestHandlerActivity` would return the sensitive Shizuku binder to any caller sending the `rikka.shizuku.intent.action.REQUEST_BINDER` intent.

### ⚠️ Risk: The potential impact if left unfixed
An attacker-controlled app on the same device could exploit this vulnerability by sending a broadcast or starting the activity to obtain the Shizuku binder. With the Shizuku binder, the malicious app could gain privileged access to system APIs, potentially leading to a full system compromise or unauthorized access to sensitive user data.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix implements token-based authentication for these entry points:
*   `ShellBinderRequestHandler.handleRequest` now accepts a `requireAuth` parameter to verify the `auth` extra in the intent against the manager's auth token.
*   `BinderRequestReceiver` now extends `AuthenticatedReceiver`, which automatically handles token verification.
*   `ShellRequestHandlerActivity` now manually verifies the auth token before processing the request and shows a notification to the user if an invalid or missing token is detected.
*   `ShizukuShellLoader` (the client side) has been updated to read the auth token from a `SHIZUKU_TOKEN` environment variable and include it in the request intent.
*   The `rish` script includes documentation on how to provide the token if authentication is required.

---
*PR created automatically by Jules for task [16054097103370357010](https://jules.google.com/task/16054097103370357010) started by @thejaustin*