### PR TITLE
⚡ Optimize ActivityLog cleanup

### DIFF
--- a/database/src/main/java/af/shizuku/manager/database/ActivityLogDao.kt
+++ b/database/src/main/java/af/shizuku/manager/database/ActivityLogDao.kt
@@ -59,6 +59,15 @@ interface ActivityLogDao {
     suspend fun clear()
 
     /**
+     * Delete activity logs except for the most recent ones.
+     *
+     * @param limit The number of most recent records to keep.
+     * @return Number of rows deleted.
+     */
+    @Query("DELETE FROM activity_logs WHERE id NOT IN (SELECT id FROM (SELECT id FROM activity_logs ORDER BY timestamp DESC, id DESC LIMIT :limit))")
+    suspend fun deleteExcess(limit: Int): Int
+
+    /**
      * Delete activity logs older than the specified timestamp.
      *
      * @param timestamp Unix timestamp in milliseconds. Logs with timestamp less than this value will be deleted.

--- a/manager/src/main/java/af/shizuku/manager/utils/ActivityLogManager.kt
+++ b/manager/src/main/java/af/shizuku/manager/utils/ActivityLogManager.kt
@@ -250,14 +250,9 @@ object ActivityLogManager {
         
         scope.launch {
             try {
-                val count = dao?.getCount() ?: 0
-                if (count > retentionCount) {
-                    val logs = dao!!.getAll().first()
-                    if (logs.size > retentionCount) {
-                        val cutoffTimestamp = logs[retentionCount - 1].timestamp
-                        val deleted = dao!!.deleteOlderThan(cutoffTimestamp)
-                        Timber.tag(TAG).d("Cleaned up $deleted old records")
-                    }
+                val deleted = dao?.deleteExcess(retentionCount) ?: 0
+                if (deleted > 0) {
+                    Timber.tag(TAG).d("Cleaned up $deleted old records")
                 }
             } catch (e: Exception) {
                 Timber.tag(TAG).e(e, "Error cleaning up old records")


### PR DESCRIPTION
💡 **What:** Optimized the activity log cleanup process by implementing a single database-side `DELETE` operation in `ActivityLogDao` that preserves the N most recent records.

🎯 **Why:** The previous implementation was inefficient as it fetched all log records from the database into memory (`O(N)` memory and I/O) just to find a cutoff timestamp, and then performed a second database operation to delete older records. This could lead to high memory pressure and performance degradation as the log grew.

📊 **Measured Improvement:** 
- **Memory:** Reduced from `O(N)` where N is the number of logs, to `O(1)` as no log records are loaded into the JVM heap during cleanup.
- **I/O:** Reduced from multiple queries (count + fetch + delete) to a single `DELETE` operation.
- **Robustness:** Added deterministic sorting (timestamp + id) for more consistent record retention and eliminated a potential `IndexOutOfBoundsException` when retention count was zero.
- **Environment Note:** Actual execution times could not be benchmarked in the sandbox due to gradle timeouts, but the theoretical performance gains for memory and database I/O are significant.

---
*PR created automatically by Jules for task [796054135728548568](https://jules.google.com/task/796054135728548568) started by @thejaustin*