### PR TITLE
🧹 [Code Health] Fix empty catch blocks in RootCompatHelper

### DIFF
--- a/manager/src/main/java/af/shizuku/manager/utils/RootCompatHelper.kt
+++ b/manager/src/main/java/af/shizuku/manager/utils/RootCompatHelper.kt
@@ -131,8 +131,8 @@ object RootCompatHelper {
             val process = Shizuku.newProcess(cmd, null, null)
             
             // Start threads to drain output/error streams to prevent buffer-fill hangs
-            val outDrainer = Thread { try { process.inputStream.bufferedReader().use { it.readText() } } catch (e: Exception) {} }
-            val errDrainer = Thread { try { process.errorStream.bufferedReader().use { it.readText() } } catch (e: Exception) {} }
+            val outDrainer = Thread { try { process.inputStream.bufferedReader().use { it.readText() } } catch (e: Exception) { Timber.w(e, "Failed to drain stream") } }
+            val errDrainer = Thread { try { process.errorStream.bufferedReader().use { it.readText() } } catch (e: Exception) { Timber.w(e, "Failed to drain stream") } }
             outDrainer.start()
             errDrainer.start()
 


### PR DESCRIPTION
🎯 **What:** Replaced empty catch blocks with Timber logging in the output and error drainer threads in `RootCompatHelper.kt`.
💡 **Why:** Empty catch blocks hide errors, making debugging difficult. Logging these stream errors using Timber will provide better visibility while preventing crashes.
✅ **Verification:** Ran `./gradlew manager:test` to confirm the change. Encountered some pre-existing build errors (e.g. `Unresolved reference 'isLiveActivityEnabled'`), but verified these errors exist prior to the modifications via `git stash`. The logging change is safe and did not introduce new issues.
✨ **Result:** Improved debugging capability and codebase maintainability without changing system behavior.

---
*PR created automatically by Jules for task [9488953623565225786](https://jules.google.com/task/9488953623565225786) started by @thejaustin*