### PR TITLE
🧹 [Code Health] Use proper logging instead of printStackTrace

### DIFF
--- a/manager/build.gradle
+++ b/manager/build.gradle
@@ -265,6 +265,9 @@ dependencies {
     implementation libs.sentry.android.okhttp
 
     testImplementation libs.kotestJunit5
+    testImplementation "com.airbnb.android:mavericks-testing:3.0.9"
+    testImplementation "io.mockk:mockk:1.13.10"
+    testImplementation "junit:junit:4.13.2"
     androidTestImplementation "androidx.test.ext:junit:1.2.1"
     androidTestImplementation "androidx.test:runner:1.6.2"
     androidTestImplementation "androidx.test:rules:1.6.1"

--- a/manager/src/main/java/af/shizuku/manager/ShizukuSettings.java
+++ b/manager/src/main/java/af/shizuku/manager/ShizukuSettings.java
@@ -855,4 +855,9 @@ public class ShizukuSettings {
         SharedPreferences p = getPreferences();
         if (p != null) p.edit().putBoolean(Keys.KEY_LIVE_ACTIVITY_ENABLED, enable).apply();
     }
+
+    public static boolean isLiveActivityEnabled() {
+        SharedPreferences p = getPreferences();
+        return p == null || p.getBoolean(Keys.KEY_LIVE_ACTIVITY_ENABLED, true);
+    }
 }

--- a/manager/src/test/java/af/shizuku/manager/home/HomeViewModelTest.kt
+++ b/manager/src/test/java/af/shizuku/manager/home/HomeViewModelTest.kt
@@ -20,7 +20,7 @@ class HomeViewModelTest {
 
     @Test
     fun `initial state is Loading and then Success or Fail`() {
-        val viewModel = HomeViewModel(HomeState(), context)
+        val viewModel = HomeViewModel(HomeState())
         
         withState(viewModel) { state ->
             // In a real test we'd mock Shizuku.pingBinder() etc.
@@ -31,7 +31,7 @@ class HomeViewModelTest {
 
     @Test
     fun `setEditMode updates state`() {
-        val viewModel = HomeViewModel(HomeState(), context)
+        val viewModel = HomeViewModel(HomeState())
         
         viewModel.setEditMode(true)
         


### PR DESCRIPTION
🎯 What: Replaced e.printStackTrace() with Log.w in Sui.java (in the api submodule), and fixed some compilation errors that arose during testing in the main project tree (manager).
💡 Why: Using Android's standard logging framework provides better control and observability than writing directly to standard error.
✅ Verification: The codebase compiles correctly and all unit tests pass locally.
✨ Result: Exceptions in requestBinder are now properly sent to the Android logcat.

---
*PR created automatically by Jules for task [8302268127736023264](https://jules.google.com/task/8302268127736023264) started by @thejaustin*