### PR TITLE
🧹 Refactor Thread.sleep in ShizukuService to conditionally use Handlers

### DIFF
--- a/server/src/main/java/rikka/shizuku/server/ShizukuService.java
+++ b/server/src/main/java/rikka/shizuku/server/ShizukuService.java
@@ -1191,20 +1191,33 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
             try {
                 LOGGER.e("kill %s in user %d and try again", MANAGER_APPLICATION_ID, userId);
                 ActivityManagerApis.forceStopPackageNoThrow(MANAGER_APPLICATION_ID, userId);
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    LOGGER.w(e, "Interrupted while sleeping before retry");
-                    Thread.currentThread().interrupt();
-                }
-                success = sendBinderToUserApp(binder, MANAGER_APPLICATION_ID, userId);
-                if (success) {
-                    LOGGER.e("retry succeeded");
+
+                Runnable retryAction = () -> {
+                    try {
+                        boolean retrySuccess = sendBinderToUserApp(binder, MANAGER_APPLICATION_ID, userId);
+                        if (retrySuccess) {
+                            LOGGER.e("retry succeeded");
+                        } else {
+                            LOGGER.e("retry failed");
+                        }
+                    } catch (Throwable tr) {
+                        LOGGER.e(tr, "retry failed");
+                    }
+                };
+
+                if (Looper.myLooper() == Looper.getMainLooper()) {
+                    HandlerUtil.getMainHandler().postDelayed(retryAction, 1000);
                 } else {
-                    LOGGER.e("retry failed");
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e) {
+                        LOGGER.w(e, "Interrupted while sleeping before retry");
+                        Thread.currentThread().interrupt();
+                    }
+                    retryAction.run();
                 }
             } catch (Throwable tr) {
-                LOGGER.e(tr, "retry failed");
+                LOGGER.e(tr, "kill failed");
             }
         }
     }


### PR DESCRIPTION
🎯 **What:** Modified `ShizukuService.sendBinderToManager` to conditionally use `HandlerUtil.getMainHandler().postDelayed(...)` instead of `Thread.sleep(...)` when executing on the main thread.
💡 **Why:** `Thread.sleep` blocks the thread unconditionally. In an asynchronous or UI environment, this causes stuttering and ANRs. This conditional refactor correctly preserves the synchronous binder responses required by clients on background threads, while offloading delays on the main thread to handlers.
✅ **Verification:** Verified by building and passing local tests in the `server` module using Gradle. All compilation checks and standard test suites pass as expected.
✨ **Result:** Improved overall codebase health and thread safety by avoiding UI thread blocking while preserving core functionality.

---
*PR created automatically by Jules for task [8808455740715873725](https://jules.google.com/task/8808455740715873725) started by @thejaustin*