### PR TITLE
🧹 code health: Replace System.out/err with Logger in shell classes

### DIFF
--- a/manager/src/main/java/af/shizuku/manager/shell/PlusShell.java
+++ b/manager/src/main/java/af/shizuku/manager/shell/PlusShell.java
@@ -22,30 +22,31 @@ public class PlusShell {
 
     private static final Logger LOGGER = new Logger("PlusShell");
 
+    private static final Logger LOGGER = new Logger("PlusShell");
+
     private static void printHelp() {
-        System.out.println("Shizuku+ CLI Helper (plus)");
-        System.out.println("Usage: plus [command] [args]");
-        System.out.println("");
-        System.out.println("Commands:");
-        System.out.println("  vm list                   List all Microdroid VMs");
-        System.out.println("  vm [start|stop|delete|status] [name]   Manage a specific VM");
-        System.out.println("  aicore [touch|swipe|text|dump|pixel]   AI Automation & Intelligence");
-        System.out.println("  storage [ls|cat|rm|mkdir|stat] [path]  Manage privileged storage");
-        System.out.println("  am [freeze|unfreeze|stop|clear|kill-all] [pkg]  Manage app state");
-        System.out.println("  wm [immersive|dex-high-refresh] [on|off]  Manage display and windows");
-        System.out.println("  su [command]              Run command via SU Bridge");
-        System.out.println("  reboot [recovery|download] Reboot to specialized modes");
-        System.out.println("  appops [pkg]              Elevate permissions for package");
-        System.out.println("  log                       View the privileged activity log (server-side)");
-        System.out.println("  doctor                    Run system diagnostics");
-        System.out.println("  spoof                     View current device identity spoofing");
-        System.out.println("  help                      Show this help message");
-        System.out.flush();
+        LOGGER.i("Shizuku+ CLI Helper (plus)");
+        LOGGER.w("Usage: plus [command] [args]");
+        LOGGER.i("");
+        LOGGER.i("Commands:");
+        LOGGER.i("  vm list                   List all Microdroid VMs");
+        LOGGER.i("  vm [start|stop|delete|status] [name]   Manage a specific VM");
+        LOGGER.i("  aicore [touch|swipe|text|dump|pixel]   AI Automation & Intelligence");
+        LOGGER.i("  storage [ls|cat|rm|mkdir|stat] [path]  Manage privileged storage");
+        LOGGER.i("  am [freeze|unfreeze|stop|clear|kill-all] [pkg]  Manage app state");
+        LOGGER.i("  wm [immersive|dex-high-refresh] [on|off]  Manage display and windows");
+        LOGGER.i("  su [command]              Run command via SU Bridge");
+        LOGGER.i("  reboot [recovery|download] Reboot to specialized modes");
+        LOGGER.i("  appops [pkg]              Elevate permissions for package");
+        LOGGER.i("  log                       View the privileged activity log (server-side)");
+        LOGGER.i("  doctor                    Run system diagnostics");
+        LOGGER.i("  spoof                     View current device identity spoofing");
+        LOGGER.i("  help                      Show this help message");
     }
 
     private static void handleSu(String[] args, IBinder binder) throws RemoteException {
         if (args.length < 2) {
-            System.out.println("Usage: plus su [command]");
+            LOGGER.w("Usage: plus su [command]");
             return;
         }
 
@@ -56,31 +57,31 @@ public class PlusShell {
         IShizukuService service = IShizukuService.Stub.asInterface(binder);
         // This will be intercepted by ShizukuService.newProcess
         service.newProcess(fullCmd, null, null);
-        System.out.println("Command sent to SU Bridge.");
+        LOGGER.i("Command sent to SU Bridge.");
     }
 
     private static void handleAppOps(String[] args, IBinder binder) throws RemoteException {
         if (args.length < 2) {
-            System.out.println("Usage: plus appops [package_name]");
+            LOGGER.w("Usage: plus appops [package_name]");
             return;
         }
 
         String packageName = args[1];
-        System.out.println("Requesting permission elevation for: " + packageName);
+        LOGGER.i("Requesting permission elevation for: " + packageName);
 
         IShizukuService service = IShizukuService.Stub.asInterface(binder);
         service.elevateApp(packageName);
-        System.out.println("Elevation request sent to server.");
+        LOGGER.i("Elevation request sent to server.");
     }
 
     private static void handleReboot(String[] args) {
         String mode = args.length > 1 ? args[1] : "";
         try {
             String[] cmd = mode.isEmpty() ? new String[]{"reboot"} : new String[]{"reboot", mode};
-            System.out.println("Rebooting to " + (mode.isEmpty() ? "system" : mode) + "...");
+            LOGGER.i("Rebooting to " + (mode.isEmpty() ? "system" : mode) + "...");
             Runtime.getRuntime().exec(cmd).waitFor();
         } catch (Exception e) {
-            System.err.println("Reboot failed: " + e.getMessage());
+            LOGGER.e("Reboot failed: " + e.getMessage());
         }
     }
 
@@ -88,26 +89,25 @@ public class PlusShell {
         IShizukuService service = IShizukuService.Stub.asInterface(binder);
         List<String> logs = service.getRecentLogs();
         if (logs == null || logs.isEmpty()) {
-            System.out.println("No recent privileged activities recorded in server buffer.");
+            LOGGER.i("No recent privileged activities recorded in server buffer.");
         } else {
-            System.out.println("Recent Privileged Activities (Server-side Buffer):");
+            LOGGER.i("Recent Privileged Activities (Server-side Buffer):");
             for (String log : logs) {
-                System.out.println(log);
+                LOGGER.i(log);
             }
         }
-        System.out.flush();
     }
 
     private static void handleVm(String[] args, IBinder binder) throws RemoteException {
         if (args.length < 2) {
-            System.out.println("Usage: plus vm [list|start|stop|delete|status]");
+            LOGGER.w("Usage: plus vm [list|start|stop|delete|status]");
             return;
         }
 
         IShizukuService service = IShizukuService.Stub.asInterface(binder);
         IVirtualMachineManager vmManager = service.getVirtualMachineManager();
         if (vmManager == null) {
-            System.out.println("Error: VM Manager feature is disabled in Shizuku+ settings.");
+            LOGGER.e("Error: VM Manager feature is disabled in Shizuku+ settings.");
             return;
         }
         
@@ -117,57 +117,57 @@ public class PlusShell {
         switch (command) {
             case "list":
                 List<String> vms = vmManager.list();
-                if (vms.isEmpty()) System.out.println("No Microdroid VMs found.");
+                if (vms.isEmpty()) LOGGER.i("No Microdroid VMs found.");
                 else {
-                    System.out.println("Microdroid VMs:");
-                    for (String vm : vms) System.out.println("  - " + vm);
+                    LOGGER.i("Microdroid VMs:");
+                    for (String vm : vms) LOGGER.i("  - " + vm);
                 }
                 break;
             case "start":
-                if (name == null) System.out.println("Usage: plus vm start [name]");
+                if (name == null) LOGGER.w("Usage: plus vm start [name]");
                 else {
-                    System.out.println("Starting VM: " + name);
-                    if (vmManager.start(name)) System.out.println("VM started successfully.");
-                    else System.out.println("Failed to start VM.");
+                    LOGGER.i("Starting VM: " + name);
+                    if (vmManager.start(name)) LOGGER.i("VM started successfully.");
+                    else LOGGER.e("Failed to start VM.");
                 }
                 break;
             case "stop":
-                if (name == null) System.out.println("Usage: plus vm stop [name]");
+                if (name == null) LOGGER.w("Usage: plus vm stop [name]");
                 else {
-                    if (vmManager.stop(name)) System.out.println("VM stopped.");
-                    else System.out.println("Failed to stop VM.");
+                    if (vmManager.stop(name)) LOGGER.i("VM stopped.");
+                    else LOGGER.e("Failed to stop VM.");
                 }
                 break;
             case "delete":
-                if (name == null) System.out.println("Usage: plus vm delete [name]");
+                if (name == null) LOGGER.w("Usage: plus vm delete [name]");
                 else {
-                    if (vmManager.delete(name)) System.out.println("VM deleted.");
-                    else System.out.println("Failed to delete VM.");
+                    if (vmManager.delete(name)) LOGGER.i("VM deleted.");
+                    else LOGGER.e("Failed to delete VM.");
                 }
                 break;
             case "status":
-                if (name == null) System.out.println("Usage: plus vm status [name]");
+                if (name == null) LOGGER.w("Usage: plus vm status [name]");
                 else {
                     String status = vmManager.getStatus(name);
-                    System.out.println("VM Status (" + name + "): " + (status != null ? status : "UNKNOWN"));
+                    LOGGER.i("VM Status (" + name + "): " + (status != null ? status : "UNKNOWN"));
                 }
                 break;
             default:
-                System.out.println("Unknown VM command: " + command);
-                System.out.println("Usage: plus vm [list|start|stop|delete|status]");
+                LOGGER.w("Unknown VM command: " + command);
+                LOGGER.w("Usage: plus vm [list|start|stop|delete|status]");
         }
     }
 
     private static void handleAm(String[] args, IBinder binder) throws RemoteException {
         if (args.length < 2) {
-            System.out.println("Usage: plus am [freeze|unfreeze|stop|kill-all] [package_name]");
+            LOGGER.w("Usage: plus am [freeze|unfreeze|stop|kill-all] [package_name]");
             return;
         }
 
         IShizukuService service = IShizukuService.Stub.asInterface(binder);
         af.shizuku.server.IActivityManagerPlus am = service.getActivityManagerPlus();
         if (am == null) {
-            System.out.println("Error: Activity Manager Plus feature is disabled in Shizuku+ settings.");
+            LOGGER.e("Error: Activity Manager Plus feature is disabled in Shizuku+ settings.");
             return;
         }
 
@@ -176,53 +176,52 @@ public class PlusShell {
 
         switch (command) {
             case "freeze":
-                if (packageName == null) System.out.println("Usage: plus am freeze [package]");
+                if (packageName == null) LOGGER.w("Usage: plus am freeze [package]");
                 else {
-                    if (am.freezeApp(packageName)) System.out.println("App frozen: " + packageName);
-                    else System.out.println("Failed to freeze app.");
+                    if (am.freezeApp(packageName)) LOGGER.i("App frozen: " + packageName);
+                    else LOGGER.e("Failed to freeze app.");
                 }
                 break;
             case "unfreeze":
-                if (packageName == null) System.out.println("Usage: plus am unfreeze [package]");
+                if (packageName == null) LOGGER.w("Usage: plus am unfreeze [package]");
                 else {
-                    if (am.unfreezeApp(packageName)) System.out.println("App unfrozen: " + packageName);
-                    else System.out.println("Failed to unfreeze app.");
+                    if (am.unfreezeApp(packageName)) LOGGER.i("App unfrozen: " + packageName);
+                    else LOGGER.e("Failed to unfreeze app.");
                 }
                 break;
             case "stop":
-                if (packageName == null) System.out.println("Usage: plus am stop [package]");
+                if (packageName == null) LOGGER.w("Usage: plus am stop [package]");
                 else {
-                    if (am.deepForceStop(packageName)) System.out.println("App force-stopped: " + packageName);
-                    else System.out.println("Failed to stop app.");
+                    if (am.deepForceStop(packageName)) LOGGER.i("App force-stopped: " + packageName);
+                    else LOGGER.e("Failed to stop app.");
                 }
                 break;
             case "clear":
-                if (packageName == null) System.out.println("Usage: plus am clear [package]");
+                if (packageName == null) LOGGER.w("Usage: plus am clear [package]");
                 else {
-                    if (am.clearAppData(packageName)) System.out.println("App data cleared: " + packageName);
-                    else System.out.println("Failed to clear app data.");
+                    if (am.clearAppData(packageName)) LOGGER.i("App data cleared: " + packageName);
+                    else LOGGER.e("Failed to clear app data.");
                 }
                 break;
             case "kill-all":
-                if (am.killAllBackgroundProcesses()) System.out.println("All background processes killed.");
-                else System.out.println("Failed to kill processes.");
+                if (am.killAllBackgroundProcesses()) LOGGER.i("All background processes killed.");
+                else LOGGER.e("Failed to kill processes.");
                 break;
             default:
-                System.out.println("Unknown am command: " + command);
+                LOGGER.w("Unknown am command: " + command);
         }
-        System.out.flush();
     }
 
     private static void handleWm(String[] args, IBinder binder) throws RemoteException {
         if (args.length < 3) {
-            System.out.println("Usage: plus wm [immersive|dex-high-refresh] [on|off]");
+            LOGGER.w("Usage: plus wm [immersive|dex-high-refresh] [on|off]");
             return;
         }
 
         IShizukuService service = IShizukuService.Stub.asInterface(binder);
         af.shizuku.server.IWindowManagerPlus wm = service.getWindowManagerPlus();
         if (wm == null) {
-            System.out.println("Error: Window Manager Plus feature is disabled.");
+            LOGGER.e("Error: Window Manager Plus feature is disabled.");
             return;
         }
 
@@ -232,109 +231,107 @@ public class PlusShell {
         switch (command) {
             case "immersive":
                 wm.setImmersiveMode(enabled);
-                System.out.println("Immersive mode: " + (enabled ? "ON" : "OFF"));
+                LOGGER.i("Immersive mode: " + (enabled ? "ON" : "OFF"));
                 break;
             case "dex-high-refresh":
                 wm.setDexHighRefreshRate(enabled);
-                System.out.println("DeX High Refresh Rate (120Hz): " + (enabled ? "ON" : "OFF"));
+                LOGGER.i("DeX High Refresh Rate (120Hz): " + (enabled ? "ON" : "OFF"));
                 break;
             default:
-                System.out.println("Unknown wm command: " + command);
+                LOGGER.w("Unknown wm command: " + command);
         }
-        System.out.flush();
     }
 
     private static void handleAiCore(String[] args, IBinder binder) throws RemoteException {
         if (args.length < 2) {
-            System.out.println("Usage: plus aicore [touch|swipe|text|dump|pixel|context] [args]");
+            LOGGER.w("Usage: plus aicore [touch|swipe|text|dump|pixel|context] [args]");
             return;
         }
 
         IShizukuService service = IShizukuService.Stub.asInterface(binder);
         IAICorePlus aicore = service.getAICorePlus();
         if (aicore == null) {
-            System.out.println("Error: AICore+ feature is disabled in Shizuku+ settings.");
+            LOGGER.e("Error: AICore+ feature is disabled in Shizuku+ settings.");
             return;
         }
 
         String command = args[1];
         switch (command) {
             case "touch":
-                if (args.length < 4) System.out.println("Usage: plus aicore touch [x] [y]");
+                if (args.length < 4) LOGGER.w("Usage: plus aicore touch [x] [y]");
                 else {
                     float x = Float.parseFloat(args[2]);
                     float y = Float.parseFloat(args[3]);
-                    if (aicore.simulateTouch(x, y)) System.out.println("Touch simulated at (" + x + ", " + y + ")");
-                    else System.out.println("Failed to simulate touch.");
+                    if (aicore.simulateTouch(x, y)) LOGGER.i("Touch simulated at (" + x + ", " + y + ")");
+                    else LOGGER.e("Failed to simulate touch.");
                 }
                 break;
             case "swipe":
-                if (args.length < 6) System.out.println("Usage: plus aicore swipe [x1] [y1] [x2] [y2] [duration_ms]");
+                if (args.length < 6) LOGGER.w("Usage: plus aicore swipe [x1] [y1] [x2] [y2] [duration_ms]");
                 else {
                     float x1 = Float.parseFloat(args[2]);
                     float y1 = Float.parseFloat(args[3]);
                     float x2 = Float.parseFloat(args[4]);
                     float y2 = Float.parseFloat(args[5]);
                     int duration = args.length > 6 ? Integer.parseInt(args[6]) : 300;
-                    if (aicore.simulateSwipe(x1, y1, x2, y2, duration)) System.out.println("Swipe simulated.");
-                    else System.out.println("Failed to simulate swipe.");
+                    if (aicore.simulateSwipe(x1, y1, x2, y2, duration)) LOGGER.i("Swipe simulated.");
+                    else LOGGER.e("Failed to simulate swipe.");
                 }
                 break;
             case "text":
-                if (args.length < 3) System.out.println("Usage: plus aicore text [content]");
+                if (args.length < 3) LOGGER.w("Usage: plus aicore text [content]");
                 else {
                     StringBuilder text = new StringBuilder();
                     for (int i = 2; i < args.length; i++) {
                         text.append(args[i]).append(i == args.length - 1 ? "" : " ");
                     }
-                    if (aicore.simulateText(text.toString())) System.out.println("Text input simulated.");
-                    else System.out.println("Failed to simulate text input.");
+                    if (aicore.simulateText(text.toString())) LOGGER.i("Text input simulated.");
+                    else LOGGER.e("Failed to simulate text input.");
                 }
                 break;
             case "dump":
                 String hierarchy = aicore.getWindowHierarchy();
                 if (hierarchy != null && !hierarchy.isEmpty()) {
-                    System.out.println(hierarchy);
+                    LOGGER.i(hierarchy);
                 } else {
-                    System.out.println("Error: Failed to dump window hierarchy.");
+                    LOGGER.e("Error: Failed to dump window hierarchy.");
                 }
                 break;
             case "pixel":
-                if (args.length < 4) System.out.println("Usage: plus aicore pixel [x] [y]");
+                if (args.length < 4) LOGGER.w("Usage: plus aicore pixel [x] [y]");
                 else {
                     int x = Integer.parseInt(args[2]);
                     int y = Integer.parseInt(args[3]);
                     int color = aicore.getPixelColor(x, y);
-                    System.out.printf("Pixel at (%d, %d): #%08X\n", x, y, color);
+                    LOGGER.i("Pixel at (%d, %d): #%08X", x, y, color);
                 }
                 break;
             case "context":
                 Bundle context = aicore.getSystemContext();
                 if (context != null) {
-                    System.out.println("AICore+ System Context:");
+                    LOGGER.i("AICore+ System Context:");
                     for (String key : context.keySet()) {
-                        System.out.println("  " + key + ": " + context.get(key));
+                        LOGGER.i("  " + key + ": " + context.get(key));
                     }
                 } else {
-                    System.out.println("Error: Failed to get system context.");
+                    LOGGER.e("Error: Failed to get system context.");
                 }
                 break;
             default:
-                System.out.println("Unknown aicore command: " + command);
+                LOGGER.w("Unknown aicore command: " + command);
         }
-        System.out.flush();
     }
 
     private static void handleStorage(String[] args, IBinder binder) throws RemoteException {
         if (args.length < 3) {
-            System.out.println("Usage: plus storage [ls|cat|rm|mkdir|stat] [path]");
+            LOGGER.w("Usage: plus storage [ls|cat|rm|mkdir|stat] [path]");
             return;
         }
 
         IShizukuService service = IShizukuService.Stub.asInterface(binder);
         IStorageProxy storage = service.getStorageProxy();
         if (storage == null) {
-            System.out.println("Error: Storage Proxy feature is disabled in Shizuku+ settings.");
+            LOGGER.e("Error: Storage Proxy feature is disabled in Shizuku+ settings.");
             return;
         }
 
@@ -345,15 +342,15 @@ public class PlusShell {
             case "ls":
                 List<String> files = storage.listFiles(path);
                 if (files == null) {
-                    System.out.println("Error: Could not access path or directory empty.");
+                    LOGGER.e("Error: Could not access path or directory empty.");
                 } else {
-                    for (String file : files) System.out.println(file);
+                    for (String file : files) LOGGER.i(file);
                 }
                 break;
             case "cat":
                 try (android.os.ParcelFileDescriptor pfd = storage.openFile(path, 0x10000000 /* MODE_READ_ONLY */)) {
                     if (pfd == null) {
-                        System.out.println("Error: Could not open file: " + path);
+                        LOGGER.e("Error: Could not open file: " + path);
                         return;
                     }
                     try (java.io.FileInputStream fis = new java.io.FileInputStream(pfd.getFileDescriptor())) {
@@ -364,33 +361,32 @@ public class PlusShell {
                         }
                     }
                 } catch (java.io.IOException e) {
-                    System.err.println("Error reading file: " + e.getMessage());
+                    LOGGER.e("Error reading file: " + e.getMessage());
                 }
                 break;
             case "rm":
-                if (storage.delete(path)) System.out.println("Deleted: " + path);
-                else System.out.println("Failed to delete: " + path);
+                if (storage.delete(path)) LOGGER.i("Deleted: " + path);
+                else LOGGER.e("Failed to delete: " + path);
                 break;
             case "mkdir":
-                if (storage.mkdir(path)) System.out.println("Created directory: " + path);
-                else System.out.println("Failed to create directory: " + path);
+                if (storage.mkdir(path)) LOGGER.i("Created directory: " + path);
+                else LOGGER.e("Failed to create directory: " + path);
                 break;
             case "stat":
                 Bundle info = storage.getFileInfo(path);
                 if (info.getBoolean("exists")) {
-                    System.out.println("File: " + path);
-                    System.out.println("Size: " + info.getLong("size") + " bytes");
-                    System.out.println("Last Modified: " + new java.util.Date(info.getLong("lastModified")));
-                    System.out.println("Type: " + (info.getBoolean("isDirectory") ? "Directory" : "File"));
+                    LOGGER.i("File: " + path);
+                    LOGGER.i("Size: " + info.getLong("size") + " bytes");
+                    LOGGER.i("Last Modified: " + new java.util.Date(info.getLong("lastModified")));
+                    LOGGER.i("Type: " + (info.getBoolean("isDirectory") ? "Directory" : "File"));
                 } else {
-                    System.out.println("Path does not exist: " + path);
+                    LOGGER.i("Path does not exist: " + path);
                 }
                 break;
             default:
-                System.out.println("Unknown storage command: " + command);
-                System.out.println("Usage: plus storage [ls|cat|rm|mkdir|stat] [path]");
+                LOGGER.w("Unknown storage command: " + command);
+                LOGGER.w("Usage: plus storage [ls|cat|rm|mkdir|stat] [path]");
         }
-        System.out.flush();
     }
 
     private static void handleSpoof(IBinder binder) throws RemoteException {
@@ -398,34 +394,35 @@ public class PlusShell {
         boolean enabled = service.isPlusFeatureEnabled("spoof_device");
         String target = service.getPlusSetting("spoof_target");
         
-        System.out.println("Identity Spoofing: " + (enabled ? "ACTIVE" : "DISABLED"));
+        LOGGER.i("Identity Spoofing: " + (enabled ? "ACTIVE" : "DISABLED"));
         if (enabled) {
-            System.out.println("Current Target: " + (target != null ? target : "None (Default)"));
+            LOGGER.i("Current Target: " + (target != null ? target : "None (Default)"));
         }
-        System.out.println("Note: Spoof targets are managed via Shizuku+ Settings > Root Compatibility.");
+        LOGGER.i("Note: Spoof targets are managed via Shizuku+ Settings > Root Compatibility.");
     }
 
     private static void handleDoctor(IBinder binder) throws RemoteException {
         IShizukuService service = IShizukuService.Stub.asInterface(binder);
-        System.out.println("Shizuku+ System Doctor Diagnostics");
-        System.out.println("==================================");
-        System.out.println("Server Version: " + service.getVersion());
-        System.out.println("Server UID: " + service.getUid());
-        System.out.println("SELinux Context: " + service.getSELinuxContext());
+        LOGGER.i("Shizuku+ System Doctor Diagnostics");
+        LOGGER.i("==================================");
+        LOGGER.i("Server Version: " + service.getVersion());
+        LOGGER.i("Server UID: " + service.getUid());
+        LOGGER.i("SELinux Context: " + service.getSELinuxContext());
         
-        System.out.println("\nPlus Features Status:");
+        LOGGER.i("\nPlus Features Status:");
         String[] features = {"su_bridge", "shell_interceptor", "avf_manager", "storage_proxy", "ai_core_plus"};
         for (String f : features) {
-            System.out.printf("  %-18s: %s\n", f, service.isPlusFeatureEnabled(f) ? "ENABLED" : "DISABLED");
+            LOGGER.i("  %-18s: %s", f, service.isPlusFeatureEnabled(f) ? "ENABLED" : "DISABLED");
         }
         
-        System.out.println("\nDevice Identity:");
-        System.out.println("  Model: " + android.os.Build.MODEL);
-        System.out.println("  Brand: " + android.os.Build.BRAND);
-        System.out.println("  SDK: " + android.os.Build.VERSION.SDK_INT);
+        LOGGER.i("\nDevice Identity:");
+        LOGGER.i("  Model: " + android.os.Build.MODEL);
+        LOGGER.i("  Brand: " + android.os.Build.BRAND);
+        LOGGER.i("  SDK: " + android.os.Build.VERSION.SDK_INT);
     }
 
     public static void main(String[] args, String packageName, IBinder binder, Handler handler) {
+        timber.log.Timber.plant(new timber.log.Timber.DebugTree());
         if (args.length == 0 || args[0].equals("help")) {
             printHelp();
             System.exit(0);
@@ -469,13 +466,12 @@ public class PlusShell {
                     handleDoctor(binder);
                     break;
                 default:
-                    System.out.println("Unknown command: " + args[0]);
+                    LOGGER.w("Unknown command: " + args[0]);
                     printHelp();
             }
         } catch (Throwable tr) {
             LOGGER.e(tr, "Uncaught exception in PlusShell");
         } finally {
-            System.out.flush();
             System.exit(0);
         }
     }

--- a/manager/src/main/java/af/shizuku/manager/shell/Shell.java
+++ b/manager/src/main/java/af/shizuku/manager/shell/Shell.java
@@ -1,6 +1,7 @@
 package af.shizuku.manager.shell;
 
 import android.content.pm.PackageManager;
+import af.shizuku.manager.utils.Logger;
 import android.os.Handler;
 import android.os.IBinder;
 
@@ -11,13 +12,14 @@ import rikka.shizuku.ShizukuApiConstants;
 
 public class Shell extends Rish {
 
+    private static final Logger LOGGER = new Logger("Shell");
+
     @Override
     public void requestPermission(Runnable onGrantedRunnable) {
         if (Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED) {
             onGrantedRunnable.run();
         } else if (Shizuku.shouldShowRequestPermissionRationale()) {
-            System.err.println("Permission denied");
-            System.err.flush();
+            LOGGER.e("Permission denied");
             System.exit(1);
         } else {
             Shizuku.addRequestPermissionResultListener(new Shizuku.OnRequestPermissionResultListener() {
@@ -28,8 +30,7 @@ public class Shell extends Rish {
                     if (grantResult == PackageManager.PERMISSION_GRANTED) {
                         onGrantedRunnable.run();
                     } else {
-                        System.err.println("Permission denied");
-                        System.err.flush();
+                        LOGGER.e("Permission denied");
                         System.exit(1);
                     }
                 }
@@ -39,13 +40,13 @@ public class Shell extends Rish {
     }
 
     public static void main(String[] args, String packageName, IBinder binder, Handler handler) {
+        timber.log.Timber.plant(new timber.log.Timber.DebugTree());
         RishConfig.init(binder, ShizukuApiConstants.BINDER_DESCRIPTOR, 30000);
         Shizuku.onBinderReceived(binder, packageName);
         Shizuku.addBinderReceivedListenerSticky(() -> {
             int version = Shizuku.getVersion();
             if (version < 12) {
-                System.err.println("Rish requires server 12 (running " + version + ")");
-                System.err.flush();
+                LOGGER.e("Rish requires server 12 (running " + version + ")");
                 System.exit(1);
             }
             new Shell().start(args);

--- a/shell/src/main/java/rikka/shizuku/shell/ShizukuShellLoader.java
+++ b/shell/src/main/java/rikka/shizuku/shell/ShizukuShellLoader.java
@@ -1,6 +1,8 @@
 package rikka.shizuku.shell;
 
 import android.app.ActivityManagerNative;
+import java.util.logging.Logger;
+import java.util.logging.Level;
 import android.app.IActivityManager;
 import android.content.Intent;
 import android.os.Binder;
@@ -24,6 +26,8 @@ import stub.dalvik.system.VMRuntimeHidden;
 
 public class ShizukuShellLoader {
 
+    private static final Logger LOGGER = Logger.getLogger("ShizukuShellLoader");
+
     private static String[] args;
     private static String callingPackage;
     private static Handler handler;
@@ -39,8 +43,7 @@ public class ShizukuShellLoader {
                 if (binder != null) {
                     handler.post(() -> onBinderReceived(binder, sourceDir));
                 } else {
-                    System.err.println("Server is not running");
-                    System.err.flush();
+                    LOGGER.severe("Server is not running");
                     System.exit(1);
                 }
                 return true;
@@ -80,8 +83,7 @@ public class ShizukuShellLoader {
                 throw e;
             }
 
-            System.err.println("broadcastIntent fails on Android 8.0 or 8.1, fallback to startActivity");
-            System.err.flush();
+            LOGGER.severe("broadcastIntent fails on Android 8.0 or 8.1, fallback to startActivity");
 
             Intent activityIntent = Intent.createChooser(
                     new Intent("rikka.shizuku.intent.action.REQUEST_BINDER")
@@ -113,13 +115,11 @@ public class ShizukuShellLoader {
             cls.getDeclaredMethod("main", String[].class, String.class, IBinder.class, Handler.class)
                     .invoke(null, args, callingPackage, binder, handler);
         } catch (ClassNotFoundException tr) {
-            System.err.println("Class not found");
-            System.err.println("Make sure you have Shizuku v12.0.0 or above installed");
-            System.err.flush();
+            LOGGER.severe("Class not found");
+            LOGGER.severe("Make sure you have Shizuku v12.0.0 or above installed");
             System.exit(1);
         } catch (Throwable tr) {
-            tr.printStackTrace(System.err);
-            System.err.flush();
+            LOGGER.log(Level.SEVERE, "Exception", tr);
             System.exit(1);
         }
     }
@@ -150,8 +150,7 @@ public class ShizukuShellLoader {
         try {
             requestForBinder();
         } catch (Throwable tr) {
-            tr.printStackTrace(System.err);
-            System.err.flush();
+            LOGGER.log(Level.SEVERE, "Exception", tr);
             System.exit(1);
         }
 
@@ -167,8 +166,7 @@ public class ShizukuShellLoader {
     }
 
     private static void abort(String message) {
-        System.err.println(message);
-        System.err.flush();
+        LOGGER.severe(message);
         System.exit(1);
     }
 }


### PR DESCRIPTION
Replaces `System.out.println` and `System.err.println` with proper logging frameworks in `PlusShell.java`, `Shell.java`, and `ShizukuShellLoader.java`. 

Uses `af.shizuku.manager.utils.Logger` for the `manager` classes and `java.util.logging.Logger` for the `shell` component, since it operates without full Android initialization. Initializes Timber appropriately in the entry points to enable logging output for CLI instances.

---
*PR created automatically by Jules for task [3430839810391412202](https://jules.google.com/task/3430839810391412202) started by @thejaustin*