### PR TITLE
🔒 Add authorization validation to ShellBinderRequestHandler

### DIFF
--- a/manager/src/main/java/af/shizuku/manager/ShizukuSettings.java
+++ b/manager/src/main/java/af/shizuku/manager/ShizukuSettings.java
@@ -851,6 +851,11 @@ public class ShizukuSettings {
     }
 
 
+    public static boolean isLiveActivityEnabled() {
+        SharedPreferences p = getPreferences();
+        return p != null && p.getBoolean(Keys.KEY_LIVE_ACTIVITY_ENABLED, false);
+    }
+
     public static void setLiveActivityEnabled(boolean enable) {
         SharedPreferences p = getPreferences();
         if (p != null) p.edit().putBoolean(Keys.KEY_LIVE_ACTIVITY_ENABLED, enable).apply();

--- a/manager/src/main/java/af/shizuku/manager/shell/ShellBinderRequestHandler.kt
+++ b/manager/src/main/java/af/shizuku/manager/shell/ShellBinderRequestHandler.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.IBinder
 import android.os.Parcel
+import af.shizuku.manager.ShizukuSettings
 import af.shizuku.manager.ktx.loge
 import af.shizuku.manager.utils.Logger.LOGGER
 import rikka.shizuku.Shizuku
@@ -12,6 +13,14 @@ object ShellBinderRequestHandler {
 
     fun handleRequest(context: Context, intent: Intent): Boolean {
         if (intent.action != "rikka.shizuku.intent.action.REQUEST_BINDER") {
+            return false
+        }
+
+        val authToken = intent.getStringExtra("auth")
+        val expectedToken = ShizukuSettings.getAuthToken()
+
+        if (authToken.isNullOrEmpty() || authToken != expectedToken) {
+            LOGGER.w("Unauthorized binder request: invalid or missing auth token")
             return false
         }
 

--- a/shell/src/main/java/rikka/shizuku/shell/ShizukuShellLoader.java
+++ b/shell/src/main/java/rikka/shizuku/shell/ShizukuShellLoader.java
@@ -53,10 +53,15 @@ public class ShizukuShellLoader {
         Bundle data = new Bundle();
         data.putBinder("binder", receiverBinder);
 
+        String token = System.getenv("SHIZUKU_TOKEN");
         Intent intent = new Intent("rikka.shizuku.intent.action.REQUEST_BINDER")
                 .setPackage("af.shizuku.plus.api")
                 .addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
                 .putExtra("data", data);
+
+        if (!TextUtils.isEmpty(token)) {
+            intent.putExtra("auth", token);
+        }
 
         IBinder amBinder = ServiceManager.getService("activity");
         IActivityManager am;
@@ -83,14 +88,17 @@ public class ShizukuShellLoader {
             System.err.println("broadcastIntent fails on Android 8.0 or 8.1, fallback to startActivity");
             System.err.flush();
 
-            Intent activityIntent = Intent.createChooser(
-                    new Intent("rikka.shizuku.intent.action.REQUEST_BINDER")
+            Intent requestIntent = new Intent("rikka.shizuku.intent.action.REQUEST_BINDER")
                             .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                             .addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT)
-                            .putExtra("data", data),
-                    "Request binder from Shizuku"
-            );
+                            .putExtra("data", data);
+
+            if (!TextUtils.isEmpty(token)) {
+                requestIntent.putExtra("auth", token);
+            }
+
+            Intent activityIntent = Intent.createChooser(requestIntent, "Request binder from Shizuku");
 
             am.startActivityAsUser(null, callingPackage, activityIntent, null, null, null, 0, 0, null, null, Os.getuid() / 100000);
         }


### PR DESCRIPTION
🎯 **What:** `ShellBinderRequestHandler` handles requests for the Shizuku Binder via `rikka.shizuku.intent.action.REQUEST_BINDER`, but it previously omitted the authentication token validation used by standard Broadcast Receivers.

⚠️ **Risk:** Any process or application capable of sending an Intent to the exposed `REQUEST_BINDER` mechanisms (e.g. `BinderRequestReceiver` or `ShellRequestHandlerActivity`) could potentially obtain the privileged Shizuku Binder, bypassing internal security restrictions.

🛡️ **Solution:** Added token verification directly into `ShellBinderRequestHandler.handleRequest`. The method now extracts the `auth` extra from the incoming Intent and strictly verifies it against `ShizukuSettings.getAuthToken()`. To ensure valid shell requests continue functioning, the `ShizukuShellLoader` has been updated to read the `SHIZUKU_TOKEN` environment variable and correctly attach it to the `auth` extra when requesting the binder.

*(Note: During compilation testing, a missing `isLiveActivityEnabled()` boolean stub in `ShizukuSettings.java` caused build errors in `manager`; this method was added to ensure the fix builds locally.)*

---
*PR created automatically by Jules for task [9336281125222270685](https://jules.google.com/task/9336281125222270685) started by @thejaustin*