### PR TITLE
🔒 fix: Secure BinderRequestReceiver by adding authentication requirement

### DIFF
--- a/manager/src/main/java/af/shizuku/manager/legacy/ShellRequestHandlerActivity.kt
+++ b/manager/src/main/java/af/shizuku/manager/legacy/ShellRequestHandlerActivity.kt
@@ -4,11 +4,19 @@ import android.os.Bundle
 import android.widget.Toast
 import af.shizuku.manager.app.AppActivity
 import af.shizuku.manager.shell.ShellBinderRequestHandler
+import af.shizuku.manager.ShizukuSettings
 
 class ShellRequestHandlerActivity : AppActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val authToken = intent.getStringExtra("auth")
+        val expectedToken = ShizukuSettings.getAuthToken()
+        if (authToken.isNullOrEmpty() || authToken != expectedToken) {
+            finish()
+            return
+        }
 
         ShellBinderRequestHandler.handleRequest(this, intent)
         finish()

--- a/manager/src/main/java/af/shizuku/manager/receiver/BinderRequestReceiver.kt
+++ b/manager/src/main/java/af/shizuku/manager/receiver/BinderRequestReceiver.kt
@@ -1,12 +1,11 @@
 package af.shizuku.manager.receiver
 
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import af.shizuku.manager.shell.ShellBinderRequestHandler
 
-class BinderRequestReceiver : BroadcastReceiver() {
-    override fun onReceive(context: Context, intent: Intent) {
+class BinderRequestReceiver : AuthenticatedReceiver() {
+    override fun onAuthenticated(context: Context, intent: Intent) {
         if (intent.action != "rikka.shizuku.intent.action.REQUEST_BINDER") return
         ShellBinderRequestHandler.handleRequest(context, intent)
     }

--- a/shell/src/main/java/rikka/shizuku/shell/ShizukuShellLoader.java
+++ b/shell/src/main/java/rikka/shizuku/shell/ShizukuShellLoader.java
@@ -53,10 +53,12 @@ public class ShizukuShellLoader {
         Bundle data = new Bundle();
         data.putBinder("binder", receiverBinder);
 
+        String token = System.getenv("SHIZUKU_TOKEN");
         Intent intent = new Intent("rikka.shizuku.intent.action.REQUEST_BINDER")
                 .setPackage("af.shizuku.plus.api")
                 .addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
-                .putExtra("data", data);
+                .putExtra("data", data)
+                .putExtra("auth", token);
 
         IBinder amBinder = ServiceManager.getService("activity");
         IActivityManager am;
@@ -88,7 +90,8 @@ public class ShizukuShellLoader {
                             .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                             .addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT)
-                            .putExtra("data", data),
+                            .putExtra("data", data)
+                            .putExtra("auth", token),
                     "Request binder from Shizuku"
             );
 


### PR DESCRIPTION
🎯 **What:** The `BinderRequestReceiver` was vulnerable as it was marked exported without enforcing intent sender identity checks. This allowed arbitrary intents with action `rikka.shizuku.intent.action.REQUEST_BINDER` to exploit `ShellBinderRequestHandler`.
⚠️ **Risk:** Any unauthorized app on the device could potentially send intent requests to exploit Shizuku's privileged shell binder context, compromising the system's security and risking unauthorized root or ADB-level execution.
🛡️ **Solution:** `BinderRequestReceiver` now inherits from `AuthenticatedReceiver` enforcing strict intent source checking based on `auth` extra. The intent sender inside `ShizukuShellLoader` has been enhanced to retrieve the `SHIZUKU_TOKEN` from environment variables, including it correctly in the outgoing intent payloads (broadcasts and fallback activity launches). The legacy `ShellRequestHandlerActivity` was also patched to perform the identical check to close out any parallel vulnerabilities.

---
*PR created automatically by Jules for task [1367138564057366674](https://jules.google.com/task/1367138564057366674) started by @thejaustin*