### PR TITLE
Keep BinderContainer wire classes and deliver the binder to stock clients

### DIFF
--- a/server/src/main/java/rikka/shizuku/server/ShizukuService.java
+++ b/server/src/main/java/rikka/shizuku/server/ShizukuService.java
@@ -314,28 +314,15 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
                 LOGGER.w(e, "grant WRITE_SECURE_SETTINGS");
             }
         }
+        // bindApplication is a oneway callback: a wrong-descriptor call fails silently on the client
+        // and never throws here, so the previous try/catch legacy fallback never actually ran.
+        // Dispatch via BOTH the af and moe descriptors (AppBinderCompat) so stock Shizuku clients
+        // (e.g. Obtainium) receive it. AppBinderCompat catches per-descriptor failures internally;
+        // wrap defensively so nothing can propagate out of this Binder entrypoint.
         try {
-            // First try using the current descriptor (af.shizuku.server.IShizukuApplication)
-            application.bindApplication(reply);
+            AppBinderCompat.bindApplication(application, reply);
         } catch (Throwable e) {
-            // If it fails (likely due to interface descriptor mismatch on the client side),
-            // try using the legacy descriptor (moe.shizuku.server.IShizukuApplication)
-            LOGGER.w("attachApplication via current descriptor failed, trying legacy descriptor for " + requestPackageName);
-            try {
-                Parcel data = Parcel.obtain();
-                try {
-                    data.writeInterfaceToken("moe.shizuku.server.IShizukuApplication");
-                    // 1 = bindApplication(Bundle)
-                    data.writeInt(1);
-                    reply.writeToParcel(data, 0);
-                    application.asBinder().transact(1, data, null, IBinder.FLAG_ONEWAY);
-                    LOGGER.i("Successfully sent bindApplication via legacy descriptor to " + requestPackageName);
-                } finally {
-                    data.recycle();
-                }
-            } catch (Throwable e2) {
-                LOGGER.e(e2, "attachApplication legacy also failed for " + requestPackageName);
-            }
+            LOGGER.w(e, "bindApplication dispatch failed for " + requestPackageName);
         }
     }
 


### PR DESCRIPTION
### Summary
Client-app half of the stock-Shizuku compatibility fix. Pairs with **thejaustin/ShizukuPlus-API#16** (please merge that first — see note below).

### Changes
- `manager/proguard-rules.pro`: keep `moe.shizuku.api.BinderContainer` and `rikka.shizuku.BinderContainer` so R8 doesn't rename the wire classes the server sends to stock clients.
- `ShizukuService`: route the `bindApplication` callback through `AppBinderCompat` so it reaches stock clients via the legacy descriptor.
- Bumps the `api` submodule to the commit that carries the matching server/API fixes.

### Note on ordering
This depends on ShizukuPlus-API#16 — the `ShizukuService` change calls `AppBinderCompat`, which is added there, and the submodule bump references that commit. After #16 merges, the `api` submodule pointer here should be updated to the merged commit.

### Testing
Verified on-device (Samsung Galaxy Z Fold 6, One UI 8.5 / Android 16): Obtainium's "Install via Shizuku" works with Shizuku+.

Fixes #306.

---
[![Co-developed with Claude](https://img.shields.io/badge/Co--developed%20with-Claude-D97706?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai)
