### PR TITLE
Fix manager showing "not running" / wrong version after a successful start

### DIFF
--- a/manager/src/main/java/af/shizuku/manager/home/HomeAdapter.kt
+++ b/manager/src/main/java/af/shizuku/manager/home/HomeAdapter.kt
@@ -56,6 +56,7 @@ class HomeAdapter(
     var isDragging = false
     private var isUpdating = false
     private var lastUpdateDataTime = 0L
+    private var pendingUpdate = false
     private val animatedIds = HashSet<Long>()
 
     /**
@@ -94,9 +95,22 @@ class HomeAdapter(
     override fun onCreateCreatorPool(): IndexCreatorPool = IndexCreatorPool()
 
     fun updateData() {
-        if (isUpdating) return
         val now = System.currentTimeMillis()
-        if (now - lastUpdateDataTime < 100) return
+        // On start the state changes in a rapid burst (Loading -> Success, plus state-listener and
+        // onResume reloads). Dropping throttled/in-flight requests loses the final "running" render,
+        // leaving a stale "not running" card until the user re-enters the screen. Instead of
+        // dropping, coalesce into a single trailing update so the latest state is always rendered.
+        if (isUpdating || now - lastUpdateDataTime < 100) {
+            if (!pendingUpdate) {
+                pendingUpdate = true
+                scope.launch {
+                    kotlinx.coroutines.delay(120)
+                    pendingUpdate = false
+                    updateData()
+                }
+            }
+            return
+        }
         lastUpdateDataTime = now
         isUpdating = true
         scope.launch {

--- a/manager/src/main/java/af/shizuku/manager/home/HomeViewModel.kt
+++ b/manager/src/main/java/af/shizuku/manager/home/HomeViewModel.kt
@@ -92,9 +92,10 @@ class HomeViewModel(
         // getServerPatchVersion() only reads the bindApplication cache; unlike getVersion()/getUid()
         // it has no direct-binder fallback. The manager's own client doesn't reliably receive that
         // oneway callback, so fall back to a direct binder call to read the running server's patch.
+        // Keep unknown as -1 (patch 0 is a legitimate value); the display layer decides how to
+        // render "unknown".
         val cachedPatch = Shizuku.getServerPatchVersion()
-        val patchVersion = (if (cachedPatch >= 0) cachedPatch else queryServerPatchVersion())
-            .let { if (it < 0) 0 else it }
+        val patchVersion = if (cachedPatch >= 0) cachedPatch else queryServerPatchVersion()
         val seContext = if (apiVersion >= 6) {
             try {
                 Shizuku.getSELinuxContext()
@@ -137,7 +138,12 @@ class HomeViewModel(
         return try {
             data.writeInterfaceToken("moe.shizuku.server.IShizukuService")
             val binder = Shizuku.getBinder() ?: return -1
-            binder.transact(ServerConstants.BINDER_TRANSACTION_getServerPatchVersion, data, reply, 0)
+            // transact() returns false when the server doesn't implement this code (e.g. a stock
+            // Shizuku server). Treat that as "unknown" rather than calling readException(), which
+            // would throw and log noise for an expected outcome.
+            if (!binder.transact(ServerConstants.BINDER_TRANSACTION_getServerPatchVersion, data, reply, 0)) {
+                return -1
+            }
             reply.readException()
             reply.readInt()
         } catch (e: Throwable) {

--- a/manager/src/main/java/af/shizuku/manager/home/HomeViewModel.kt
+++ b/manager/src/main/java/af/shizuku/manager/home/HomeViewModel.kt
@@ -2,6 +2,7 @@ package af.shizuku.manager.home
 
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Parcel
 import android.os.Build
 import androidx.annotation.Keep
 import androidx.annotation.RequiresApi
@@ -26,6 +27,7 @@ import af.shizuku.manager.utils.SettingsHelper
 import af.shizuku.manager.utils.ShizukuSystemApis
 import af.shizuku.manager.utils.StockShizukuCompat
 import rikka.shizuku.Shizuku
+import rikka.shizuku.server.ServerConstants
 
 @Keep
 class HomeViewModel(
@@ -87,7 +89,12 @@ class HomeViewModel(
 
         val uid = Shizuku.getUid()
         val apiVersion = Shizuku.getVersion()
-        val patchVersion = Shizuku.getServerPatchVersion().let { if (it < 0) 0 else it }
+        // getServerPatchVersion() only reads the bindApplication cache; unlike getVersion()/getUid()
+        // it has no direct-binder fallback. The manager's own client doesn't reliably receive that
+        // oneway callback, so fall back to a direct binder call to read the running server's patch.
+        val cachedPatch = Shizuku.getServerPatchVersion()
+        val patchVersion = (if (cachedPatch >= 0) cachedPatch else queryServerPatchVersion())
+            .let { if (it < 0) 0 else it }
         val seContext = if (apiVersion >= 6) {
             try {
                 Shizuku.getSELinuxContext()
@@ -97,7 +104,16 @@ class HomeViewModel(
             }
         } else null
 
-        val permissionTest = Shizuku.checkRemotePermission("android.permission.GRANT_RUNTIME_PERMISSIONS") == PackageManager.PERMISSION_GRANTED
+        // checkRemotePermission enforceCallingPermission-gates on the caller being an attached
+        // client; right after start the manager may not be attached yet, and an unguarded throw
+        // here aborts the whole status load (reload() -> Fail -> shown as "not running") even though
+        // pingBinder already confirmed the service is up. Treat a failure as "not granted".
+        val permissionTest = try {
+            Shizuku.checkRemotePermission("android.permission.GRANT_RUNTIME_PERMISSIONS") == PackageManager.PERMISSION_GRANTED
+        } catch (e: Throwable) {
+            LOGGER.w(e, "checkRemotePermission")
+            false
+        }
 
         try {
             ShizukuSystemApis.checkPermission(Manifest.permission.API_V23, BuildConfig.APPLICATION_ID, 0)
@@ -105,7 +121,32 @@ class HomeViewModel(
             LOGGER.w(e, "Permission check failed")
         }
 
-        return ServiceStatus(uid, apiVersion, patchVersion, seContext, permissionTest)
+        // pingBinder() above already succeeded, so the service is reachable and running regardless
+        // of whether the attach-gated getUid()/getVersion() calls returned valid values.
+        return ServiceStatus(uid, apiVersion, patchVersion, seContext, permissionTest, running = true)
+    }
+
+    /**
+     * Direct binder call for the running server's patch version, mirroring how Shizuku.getVersion()
+     * falls back to requireService().getVersion(). Returns -1 if unavailable (e.g. a stock Shizuku
+     * server that does not implement this transaction).
+     */
+    private fun queryServerPatchVersion(): Int {
+        val data = Parcel.obtain()
+        val reply = Parcel.obtain()
+        return try {
+            data.writeInterfaceToken("moe.shizuku.server.IShizukuService")
+            val binder = Shizuku.getBinder() ?: return -1
+            binder.transact(ServerConstants.BINDER_TRANSACTION_getServerPatchVersion, data, reply, 0)
+            reply.readException()
+            reply.readInt()
+        } catch (e: Throwable) {
+            LOGGER.w(e, "queryServerPatchVersion failed")
+            -1
+        } finally {
+            reply.recycle()
+            data.recycle()
+        }
     }
 
     fun checkBatteryOptimization() {

--- a/manager/src/main/java/af/shizuku/manager/home/ServerStatusViewHolder.kt
+++ b/manager/src/main/java/af/shizuku/manager/home/ServerStatusViewHolder.kt
@@ -178,14 +178,19 @@ class ServerStatusViewHolder(private val binding: HomeServerStatusBinding, root:
             context.getString(R.string.home_status_service_not_running, context.getString(R.string.app_name))
         }
         val summary = if (ok) {
-            if (apiVersion != Shizuku.getLatestServiceVersion() || status.patchVersion != ShizukuApiConstants.SERVER_PATCH_VERSION) {
+            // patchVersion is 0 when the server's bindApplication reply hasn't populated it yet
+            // (it can arrive slightly after the binder becomes pingable). Don't claim the server is
+            // outdated based on an unknown patch, or the "restart to update" prompt shows spuriously.
+            val patchKnown = patchVersion > 0
+            val versionText = if (patchKnown) "${apiVersion}.${patchVersion}" else "$apiVersion"
+            if (apiVersion != Shizuku.getLatestServiceVersion() || (patchKnown && patchVersion != ShizukuApiConstants.SERVER_PATCH_VERSION)) {
                 context.getString(
                     R.string.home_status_service_version_update, user,
-                    "${apiVersion}.${patchVersion}",
+                    versionText,
                     "${Shizuku.getLatestServiceVersion()}.${ShizukuApiConstants.SERVER_PATCH_VERSION}"
                 )
             } else {
-                context.getString(R.string.home_status_service_version, user, "${apiVersion}.${patchVersion}")
+                context.getString(R.string.home_status_service_version, user, versionText)
             }
         } else {
             context.getString(R.string.home_status_service_not_running, context.getString(R.string.app_name))

--- a/manager/src/main/java/af/shizuku/manager/home/ServerStatusViewHolder.kt
+++ b/manager/src/main/java/af/shizuku/manager/home/ServerStatusViewHolder.kt
@@ -178,10 +178,10 @@ class ServerStatusViewHolder(private val binding: HomeServerStatusBinding, root:
             context.getString(R.string.home_status_service_not_running, context.getString(R.string.app_name))
         }
         val summary = if (ok) {
-            // patchVersion is 0 when the server's bindApplication reply hasn't populated it yet
-            // (it can arrive slightly after the binder becomes pingable). Don't claim the server is
-            // outdated based on an unknown patch, or the "restart to update" prompt shows spuriously.
-            val patchKnown = patchVersion > 0
+            // patchVersion is -1 when unknown (not yet delivered / not supported by the server);
+            // 0 is a legitimate patch value. Don't claim the server is outdated based on an unknown
+            // patch, or the "restart to update" prompt shows spuriously.
+            val patchKnown = patchVersion >= 0
             val versionText = if (patchKnown) "${apiVersion}.${patchVersion}" else "$apiVersion"
             if (apiVersion != Shizuku.getLatestServiceVersion() || (patchKnown && patchVersion != ShizukuApiConstants.SERVER_PATCH_VERSION)) {
                 context.getString(

--- a/manager/src/main/java/af/shizuku/manager/model/ServiceStatus.kt
+++ b/manager/src/main/java/af/shizuku/manager/model/ServiceStatus.kt
@@ -1,14 +1,18 @@
 package af.shizuku.manager.model
 
-import af.shizuku.manager.utils.ShizukuStateMachine
-
 data class ServiceStatus(
         val uid: Int = -1,
         val apiVersion: Int = -1,
         val patchVersion: Int = -1,
         val seContext: String? = null,
-        val permission: Boolean = false
+        val permission: Boolean = false,
+        // Set to true by HomeViewModel.loadStatus when the binder is reachable (pingBinder). This is
+        // the authoritative "is the service running" signal: it needs no attachment, unlike getUid()
+        // which enforceCallingPermission-gates on the caller being an attached client and can return
+        // -1 for a window right after start (or when the manager's own attach races). Basing
+        // isRunning on getUid made a healthy, reachable server show as "not running".
+        val running: Boolean = false
 ) {
     val isRunning: Boolean
-        get() = uid != -1 && ShizukuStateMachine.isRunning()
+        get() = running
 }

--- a/manager/src/main/java/af/shizuku/manager/starter/Starter.kt
+++ b/manager/src/main/java/af/shizuku/manager/starter/Starter.kt
@@ -1,9 +1,8 @@
 package af.shizuku.manager.starter
 
 import android.content.Context
-import androidx.lifecycle.asFlow
 import java.io.File
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
 import af.shizuku.manager.R
 import af.shizuku.manager.utils.ShizukuStateMachine
@@ -47,10 +46,16 @@ object Starter {
         log?.invoke("\n" + getContext().getString(R.string.starter_waiting))
         val t0 = System.currentTimeMillis()
 
-        // Use withTimeout to prevent infinite hanging and trigger the error UI in StarterActivity
+        // Use withTimeout to prevent infinite hanging and trigger the error UI in StarterActivity.
+        // Actively poll pingBinder() via ShizukuStateMachine.update() rather than only awaiting the
+        // sticky OnBinderReceivedListener: on some devices that callback is delayed or missed, which
+        // leaves this screen stuck on "Waiting for service…" even though the service is already
+        // reachable. update() pings the binder and, when alive, sets the state to RUNNING (also
+        // notifying listeners so the home screen refreshes).
         withTimeout(20_000) {
-            ShizukuStateMachine.asFlow()
-                .first { it == ShizukuStateMachine.State.RUNNING }
+            while (ShizukuStateMachine.update() != ShizukuStateMachine.State.RUNNING) {
+                delay(250)
+            }
         }
 
         val elapsed = (System.currentTimeMillis() - t0) / 1000.0

--- a/server/src/main/java/rikka/shizuku/server/ServerConstants.java
+++ b/server/src/main/java/rikka/shizuku/server/ServerConstants.java
@@ -13,4 +13,8 @@ public class ServerConstants {
     public static final int BINDER_TRANSACTION_getApplications = 10001;
     public static final int BINDER_TRANSACTION_isCustomApiEnabled = 10002;
     public static final int BINDER_TRANSACTION_getDhizukuBinder = 10003;
+    // Direct getter for the running server's patch version. The patch version is otherwise only
+    // delivered via the oneway bindApplication callback, which the manager's own client doesn't
+    // reliably receive; this lets it (and any client) read it directly, like getVersion()/getUid().
+    public static final int BINDER_TRANSACTION_getServerPatchVersion = 10004;
 }

--- a/server/src/main/java/rikka/shizuku/server/ShizukuService.java
+++ b/server/src/main/java/rikka/shizuku/server/ShizukuService.java
@@ -1678,6 +1678,11 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
             reply.writeNoException();
             reply.writeStrongBinder(dpm);
             return true;
+        } else if (code == ServerConstants.BINDER_TRANSACTION_getServerPatchVersion) {
+            data.enforceInterface(ShizukuApiConstants.BINDER_DESCRIPTOR);
+            reply.writeNoException();
+            reply.writeInt(ShizukuApiConstants.SERVER_PATCH_VERSION);
+            return true;
         }
         return super.onTransact(code, data, reply, flags);
     }


### PR DESCRIPTION
### Summary
On some devices (seen on Samsung / One UI) the manager showed **"not running"** and/or only the API version (**"13"** instead of **"13.6"**) right after a successful Start — even though the server was up and client apps worked, and re-entering the screen then showed it correctly. This is a chain of manager-side races/edge cases; each fix is small and independent of the #306 client-compat work.

### Root causes & fixes
1. **`HomeAdapter.updateData` dropped renders (primary cause).** On start the state changes in a rapid burst (`Loading` → `Success`, plus the state-listener and `onResume` reloads). The throttle (`if (isUpdating || now - last < 100) return`) *silently dropped* the final "running" render, leaving a stale "not running" card until the user re-entered the screen. → coalesce a throttled/in-flight request into a single **trailing** update instead of dropping it.
2. **`ServiceStatus.isRunning` was gated on `getUid() != -1`.** `getUid()` requires the caller to be an attached client, so it can be `-1` in the window right after start → status shows not-running. → base `isRunning` on the `pingBinder()` check `loadStatus` already performs (no attachment required), via an explicit `running` flag.
3. **`loadStatus` aborted on an unguarded `checkRemotePermission()`.** For a not-yet-attached client it throws, so `reload()` → `Fail` → "not running". → guard it (treat failure as "not granted").
4. **"Waiting for service…" didn't auto-close.** `Starter.waitForBinder` only awaited the sticky `OnBinderReceivedListener`, which can be delayed/missed. → also poll `pingBinder()` via `ShizukuStateMachine.update()` so RUNNING is detected promptly.
5. **Server patch version wasn't shown / caused a spurious "restart to update".** `getServerPatchVersion()` only reads the `bindApplication` cache (no direct getter). → add a `getServerPatchVersion` binder transaction + a direct-call fallback in the manager (mirrors `getVersion()`), and only flag the server outdated when the patch is actually known.

Independent of the #306 PRs (no submodule changes) — can be reviewed/merged on its own.

### Testing
Verified on-device (Samsung Galaxy Z Fold 6, One UI 8.5 / Android 16): after a single Start, the manager auto-closes the start screen and immediately shows running with the full version, no stale "not running" and no spurious update prompt.

---
[![Co-developed with Claude](https://img.shields.io/badge/Co--developed%20with-Claude-D97706?style=flat-square&logo=anthropic&logoColor=white)](https://claude.ai)
