### PR TITLE
Add missing af.shizuku.plus.api.shizuku authority to ShizukuManagerProvider

### DIFF
--- a/manager/src/main/AndroidManifest.xml
+++ b/manager/src/main/AndroidManifest.xml
@@ -382,7 +382,7 @@
 
         <provider
             android:name=".ShizukuManagerProvider"
-            android:authorities="${applicationId}.shizuku;moe.shizuku.privileged.api"
+            android:authorities="${applicationId}.shizuku;moe.shizuku.privileged.api;af.shizuku.plus.api.shizuku"
             android:directBootAware="true"
             android:enabled="true"
             android:exported="true"


### PR DESCRIPTION
## Problem

Apps using `bindUserService()` with ShizukuPlus (DarQ-Reborn, MiXplorer, and others) report "Shizuku Not Running" or timeout errors even though ShizukuPlus is running and the app is authorized.

## Root Cause

ShizukuPlus injects a `ShizukuServiceStarter` into user service processes. During startup, this starter looks for a ContentProvider at the authority:

```
af.shizuku.plus.api.shizuku
```

But the `ShizukuManagerProvider` is currently registered only with:

```
${applicationId}.shizuku
moe.shizuku.privileged.api
```

Neither resolves to `af.shizuku.plus.api.shizuku`, so the lookup returns null. The starter then calls `System.exit(1)`, killing the service process before it can connect. The server retries until the 30-second timeout is reached, and the app never receives the `onServiceConnected` callback.

Logcat confirmation:

```
ShizukuServiceStarter: provider is null af.shizuku.plus.api.shizuku 0
```

This was discovered while debugging DarQ-Reborn. Full investigation at [Arora-Sir/DarQ-Reborn#20](https://github.com/Arora-Sir/DarQ-Reborn/issues/20).

## Fix

Add `af.shizuku.plus.api.shizuku` as an additional authority on the `ShizukuManagerProvider`:

```diff
- android:authorities="${applicationId}.shizuku;moe.shizuku.privileged.api"
+ android:authorities="${applicationId}.shizuku;moe.shizuku.privileged.api;af.shizuku.plus.api.shizuku"
```

## Verification

Binary-patched the v13.6.0.r2139 APK with this change and confirmed:
- Service process starts without `System.exit(1)`
- `onServiceConnected` fires immediately
- DarQ-Reborn detects Shizuku as running and connects successfully
- Standard Shizuku functionality is unaffected (existing authorities remain)

## Impact

This affects **all third-party apps** that use `Shizuku.bindUserService()`, not just DarQ-Reborn. Any app creating a Shizuku user service will hit this timeout when running on ShizukuPlus.
